### PR TITLE
FEATURE: Allow the new version of Carbon.IncludeAssets

### DIFF
--- a/DistributionPackages/VelpeSued.Site/composer.json
+++ b/DistributionPackages/VelpeSued.Site/composer.json
@@ -16,7 +16,7 @@
 
         "carbon/compression": "~2.0",
         "carbon/link": "~1.4",
-        "carbon/includeassets": "~3.5",
+        "carbon/includeassets": "~3.5 || ~4.0",
         "codeq/unicodenormalizer": "~2.2",
         "flowpack/cachebuster": "~1.0",
         "flowpack/nodetemplates": "~1.1",


### PR DESCRIPTION
I released a new Version of [Carbon.IncludeAssets](https://github.com/CarbonPackages/Carbon.IncludeAssets/releases/tag/4.0.0)
* Change license to GPL-3
* Add [propTypes](https://github.com/PackageFactory/atomic-fusion-proptypes)
* Add Wrapper setting: If set, the generated tags will be wrapped. `{content}` will be replaced with the tags. Example: `Wrapper: '<!--[if lt IE 9]>{content}<![endif]-->'`. You can set this property also in the Fusion prototypes `Carbon.IncludeAssets:Collection` and `Carbon.IncludeAssets:File`.
* Raise minimum Neos Version to 4.3
* Update Build script